### PR TITLE
adding run_dependent_tasks_on_fail flag

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -403,7 +403,7 @@ files = [
 
 [[package]]
 name = "cfa-azure"
-version = "1.0.13"
+version = "1.1.2"
 description = "module for use with Azure and Azure Batch"
 optional = false
 python-versions = "^3.8"
@@ -428,8 +428,8 @@ toml = "^0.10.2"
 [package.source]
 type = "git"
 url = "https://github.com/CDCgov/cfa_azure.git"
-reference = "0be3553b3a6026fb10783cdd25e36ffd55abffca"
-resolved_reference = "0be3553b3a6026fb10783cdd25e36ffd55abffca"
+reference = "3786cc8023c5412bd275b042d1fb23892aa2b6dd"
+resolved_reference = "3786cc8023c5412bd275b042d1fb23892aa2b6dd"
 
 [[package]]
 name = "cffi"
@@ -4104,4 +4104,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c62dadbe99b9bb7d66be640c14708e548ba902992ca50aea3a8379414eeeed6e"
+content-hash = "2aeb1c835f7f6e6ff586140092040b2d072b748078c91ad2611671cb3f7299dd"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache License, Version 2.0, January 2004"
 
 [tool.poetry.dependencies]
 python = "^3.10"
-cfa-azure = {git = "https://github.com/CDCgov/cfa_azure.git", rev="0be3553b3a6026fb10783cdd25e36ffd55abffca"}
+cfa-azure = {git = "https://github.com/CDCgov/cfa_azure.git", rev="3786cc8023c5412bd275b042d1fb23892aa2b6dd"}
 pandas = "^2.2.3"
 shiny = "^1.1.0"
 shinywidgets = "^0.3.3"

--- a/src/scenarios_hpc_azure/azure_utils.py
+++ b/src/scenarios_hpc_azure/azure_utils.py
@@ -235,7 +235,11 @@ class AzureExperimentLauncher:
             location_in_blob=self.experiment_path_blob,
         )
 
-    def launch_states(self, depend_on_task_ids: list[str] = None) -> list[str]:
+    def launch_states(
+        self,
+        depend_on_task_ids: list[str] = None,
+        run_dependent_tasks_on_fail: bool = False,
+    ) -> list[str]:
         """Launches an Azure Batch job under `self.job_id`,
         populating it with tasks for each subdirectory within your experiment's `states` directory
         passing each state name to `run_task.py` with the -s flag and the job_id with the -j flag.
@@ -244,6 +248,10 @@ class AzureExperimentLauncher:
         ----------
         depend_on_task_ids: list[str], optional
             list of task ids on which each state depends on finishing to start themselves, defaults to None
+
+        run_dependent_tasks_on_fail: bool, optional
+            whether or not to run postprocessing tasks regardless of the status of states
+
         Returns
         -------
         list[str]
@@ -272,6 +280,7 @@ class AzureExperimentLauncher:
                     % (self.runner_path_docker, statedir, self.job_id),
                     depends_on=depend_on_task_ids,
                     name_suffix=statedir,
+                    run_dependent_tasks_on_fail=run_dependent_tasks_on_fail,
                 )
                 # append this list onto our running list of tasks
                 task_ids += task_id
@@ -281,6 +290,7 @@ class AzureExperimentLauncher:
         self,
         task_arguments_df: pd.DataFrame,
         depend_on_task_ids: list[str] = None,
+        run_dependent_tasks_on_fail: bool = False,
     ):
         """Similar to `launch_states()` this method launches
         your states based on command line arguments provided by
@@ -296,6 +306,8 @@ class AzureExperimentLauncher:
             flag values.
         depend_on_task_ids: list[str], optional
             list of task ids on which each task depends on finishing to start themselves, defaults to None
+        run_dependent_tasks_on_fail: bool, optional
+            whether or not to run postprocessing tasks regardless of the status of states
 
         Returns
         -------
@@ -343,6 +355,7 @@ class AzureExperimentLauncher:
                 % (self.runner_path_docker, run_task_arguments),
                 depends_on=depend_on_task_ids,
                 name_suffix=state_suffix,
+                run_dependent_tasks_on_fail=run_dependent_tasks_on_fail,
             )
             # append this list onto our running list of tasks
             task_ids += task_id

--- a/src/scenarios_hpc_azure/azure_utils.py
+++ b/src/scenarios_hpc_azure/azure_utils.py
@@ -421,6 +421,7 @@ class AzureExperimentLauncher:
         execution_order: list[str | list[str]],
         depend_on_task_ids: list[str],
         postprocess_folder_name: str = "postprocessing_scripts",
+        run_dependent_tasks_on_fail: bool = False,
     ) -> list[str]:
         """Launches postprocessing scripts identified by `execution_order`
         in the order they are passed in the list. List elements are
@@ -480,6 +481,7 @@ class AzureExperimentLauncher:
                     docker_cmd="python %s -j %s"
                     % (postprocess_docker_path, self.job_id),
                     depends_on=depend_on_task_ids + postprocess_task_ids,
+                    run_dependent_tasks_on_fail=run_dependent_tasks_on_fail,
                 )
                 execution_bundle_ids += task_id
             # bundle completed, add those task ids to the running list

--- a/src/scenarios_hpc_azure/launch_experiment.py
+++ b/src/scenarios_hpc_azure/launch_experiment.py
@@ -135,8 +135,6 @@ def launch():
     timeout_mins: int = args.timeout
     explicit_csv_path: str = args.explicit
     run_dep = args.run_dependent_tasks_on_fail
-    print(type(run_dep), run_dep)
-    exit()
     docker_image_tag = "scenarios_image_%s" % job_id
     print(
         (

--- a/src/scenarios_hpc_azure/launch_experiment.py
+++ b/src/scenarios_hpc_azure/launch_experiment.py
@@ -86,7 +86,8 @@ parser.add_argument(
     required=False,
     default=8,
     metavar="",
-    help="CPU count of machines running each task, supports 2, 4, or 8 cores",
+    help="CPU count of machines running each task, supports 2, 4, or 8 cores"
+    "defaults to 8 core machine",
 )
 
 parser.add_argument(
@@ -96,7 +97,8 @@ parser.add_argument(
     required=False,
     default=600,
     metavar="",
-    help="timeout time in minutes to monitor job, does NOT terminate job after timeout is reached",
+    help="timeout time in minutes to monitor job, "
+    "does NOT terminate job after timeout is reached, defaults to 600 minutes",
 )
 
 parser.add_argument(
@@ -116,6 +118,13 @@ parser.add_argument(
     "names and values to be passed to this script",
 )
 
+parser.add_argument(
+    "--run_dependent_tasks_on_fail",
+    default=False,
+    action="store_true",
+    help="whether or not to run postprocessing scripts if any tasks fail, default to False",
+)
+
 
 def launch():
     """The entry point into launching an experiment"""
@@ -125,7 +134,9 @@ def launch():
     cpu_count: int = args.cpu
     timeout_mins: int = args.timeout
     explicit_csv_path: str = args.explicit
-
+    run_dep = args.run_dependent_tasks_on_fail
+    print(type(run_dep), run_dep)
+    exit()
     docker_image_tag = "scenarios_image_%s" % job_id
     print(
         (
@@ -173,17 +184,20 @@ def launch():
         if os.path.exists(explicit_csv_path):
             task_arguments_df = pd.read_csv(explicit_csv_path)
             state_task_ids = launcher.launch_states_explicitly(
-                task_arguments_df
+                task_arguments_df, run_dependent_tasks_on_fail=run_dep
             )
         else:
             raise FileNotFoundError(
                 "Unable to locate explicit csv at %s" % explicit_csv_path
             )
     else:  # launch default behavior
-        state_task_ids = launcher.launch_states()
+        state_task_ids = launcher.launch_states(
+            run_dependent_tasks_on_fail=run_dep
+        )
     postprocessing_tasks = launcher.launch_postprocess(
         execution_order=postprocess_execution_order,
         depend_on_task_ids=state_task_ids,
+        run_dependent_tasks_on_fail=run_dep,
     )
     all_tasks_run += state_task_ids + postprocessing_tasks
     launcher.azure_client.monitor_job(job_id, timeout=timeout_mins)

--- a/src/scenarios_hpc_azure/launch_experiment.py
+++ b/src/scenarios_hpc_azure/launch_experiment.py
@@ -157,7 +157,7 @@ def launch():
     cpu_count: int = args.cpu
     timeout_mins: int = args.timeout
     explicit_csv_path: str = args.explicit
-    run_dep = args.run_dependent_tasks_on_fail
+    run_dep: bool = args.run_dependent_tasks_on_fail
     docker_image_tag = "scenarios_image_%s" % job_id
     print(
         (


### PR DESCRIPTION
 users can now specify the run_dependent_tasks_on_fail  by appending `--run_dependent_tasks_on_fail ` to their CLI inputs. This will cause postprocessing script to execute regardless of the termination status (exit code 0 or 1) of the tasks on which they depend. 

by default postprocessing scripts will NOT execute unless all their dependencies successfully exit, but if `run_dependent_tasks_on_fail` flag is used, they will execute regardless of the exit code. 