### PR TITLE
upgrade `cfa-azure` and add `mark_complete_after_tasks_run` flag to job

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -403,7 +403,7 @@ files = [
 
 [[package]]
 name = "cfa-azure"
-version = "1.2.1"
+version = "1.3.0"
 description = "module for use with Azure and Azure Batch"
 optional = false
 python-versions = "^3.8"
@@ -428,8 +428,8 @@ toml = "^0.10.2"
 [package.source]
 type = "git"
 url = "https://github.com/CDCgov/cfa_azure.git"
-reference = "e08beb17b1838fc8749d73c08eab5097ab21cac4"
-resolved_reference = "e08beb17b1838fc8749d73c08eab5097ab21cac4"
+reference = "43f4effd2d2fc46acc0f33ae047d12dfd9481bbd"
+resolved_reference = "43f4effd2d2fc46acc0f33ae047d12dfd9481bbd"
 
 [[package]]
 name = "cffi"
@@ -4104,4 +4104,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "27462e425e60336cd93dd55fce4d8fe1673f12e905f2a60bbb14f210327110d6"
+content-hash = "1bde7a1e09fb4ca8f7655fba3c89b7892c229d5ae6813489f14e693b0e70eeb5"

--- a/poetry.lock
+++ b/poetry.lock
@@ -403,7 +403,7 @@ files = [
 
 [[package]]
 name = "cfa-azure"
-version = "1.1.2"
+version = "1.2.1"
 description = "module for use with Azure and Azure Batch"
 optional = false
 python-versions = "^3.8"
@@ -428,8 +428,8 @@ toml = "^0.10.2"
 [package.source]
 type = "git"
 url = "https://github.com/CDCgov/cfa_azure.git"
-reference = "3786cc8023c5412bd275b042d1fb23892aa2b6dd"
-resolved_reference = "3786cc8023c5412bd275b042d1fb23892aa2b6dd"
+reference = "e08beb17b1838fc8749d73c08eab5097ab21cac4"
+resolved_reference = "e08beb17b1838fc8749d73c08eab5097ab21cac4"
 
 [[package]]
 name = "cffi"
@@ -4104,4 +4104,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "2aeb1c835f7f6e6ff586140092040b2d072b748078c91ad2611671cb3f7299dd"
+content-hash = "27462e425e60336cd93dd55fce4d8fe1673f12e905f2a60bbb14f210327110d6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
 [tool.poetry]
 name = "scenarios_hpc_azure"
-version = "0.1.0"
+version = "0.1.1"
 description = "CFA Azure Acceleration library for creating, launching, and visualizing Azure experiments"
 authors = ["Your Name <you@example.com>"]
 license = "Apache License, Version 2.0, January 2004"
 
 [tool.poetry.dependencies]
 python = "^3.10"
-cfa-azure = {git = "https://github.com/CDCgov/cfa_azure.git", rev="3786cc8023c5412bd275b042d1fb23892aa2b6dd"}
+cfa-azure = {git = "https://github.com/CDCgov/cfa_azure.git", rev="e08beb17b1838fc8749d73c08eab5097ab21cac4"}
 pandas = "^2.2.3"
 shiny = "^1.1.0"
 shinywidgets = "^0.3.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache License, Version 2.0, January 2004"
 
 [tool.poetry.dependencies]
 python = "^3.10"
-cfa-azure = {git = "https://github.com/CDCgov/cfa_azure.git", rev="e08beb17b1838fc8749d73c08eab5097ab21cac4"}
+cfa-azure = {git = "https://github.com/CDCgov/cfa_azure.git", rev="43f4effd2d2fc46acc0f33ae047d12dfd9481bbd"}
 pandas = "^2.2.3"
 shiny = "^1.1.0"
 shinywidgets = "^0.3.3"

--- a/src/scenarios_hpc_azure/azure_utils.py
+++ b/src/scenarios_hpc_azure/azure_utils.py
@@ -287,7 +287,7 @@ class AzureExperimentLauncher:
                     run_dependent_tasks_on_fail=run_dependent_tasks_on_fail,
                 )
                 # append this list onto our running list of tasks
-                task_ids += task_id
+                task_ids.append(task_id)
         return task_ids
 
     def launch_states_explicitly(


### PR DESCRIPTION
`cfa-azure` now requires a `[CONTAINER]` section in the configuration toml in order to work. The section is easy to add and I will reach out to impacted parties to ensure they have it when they pull this version of `scenarios-hpc-azure`.